### PR TITLE
Fix(clustertool): Dockerhub config formatting in initfiles.go

### DIFF
--- a/clustertool/pkg/initfiles/initfiles.go
+++ b/clustertool/pkg/initfiles/initfiles.go
@@ -341,7 +341,7 @@ func setDocker() {
 		// Prepare the content to append
 		configContent := fmt.Sprintf(`
     # Add Dockerhub Login
-    config
+    config:
       registry-1.docker.io:
         auth:
           username: "%s"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
As noticed in github ticket: https://discordapp.com/channels/830763548678291466/1441342687792988262

Missing colon in `all.yaml`

Clustertool error.
```[90m2025-11-21T09:25:38+01:00[0m [31mFTL[0m [1mfailed to generate talos config: yaml: line 98: could not find expected ':'[0m [36merror=[0m[31m[1m"yaml: line 98: could not find expected ':'"[0m[0m
```

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
